### PR TITLE
Update mlflow version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
 ]
 requires-python = ">=3.9"
-dependencies = ["cffi>=1.17.1", "mlflow>=2.17.0", "psycopg2-binary==2.9.9"]
+dependencies = ["cffi>=1.17.1", "mlflow>=2.19.0", "psycopg2-binary>=2.9.9"]
 [[project.maintainers]]
 name = "Databricks"
 email = "mlflow-oss-maintainers@googlegroups.com"
@@ -56,7 +56,7 @@ exclude = ["tests", "tests.*"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py39"
 force-exclude = true
 extend-include = ["*.ipynb"]
 extend-exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -1030,7 +1030,7 @@ dev = [
 requires-dist = [
     { name = "cffi", specifier = ">=1.17.1" },
     { name = "mlflow", editable = ".mlflow.repo" },
-    { name = "psycopg2-binary", specifier = "==2.9.9" },
+    { name = "psycopg2-binary", specifier = ">=2.9.9" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
I want to update our mlflow version which is used in the published wheel.
And also loosen the version of the dreaded psycopg2-binary. (This allows for python 3.13 I believe).

Proof that these version stick, after building your wheel, run:

`tar -xzf dist/mlflow_go_backend-0.1.0-py3-none-macosx_11_0_arm64.whl -O mlflow_go_backend-0.1.0.dist-info/METADATA`

```
Project-URL: homepage, https://mlflow.org
Project-URL: issues, https://github.com/mlflow/mlflow-go-backend/issues
Project-URL: documentation, https://mlflow.org/docs/latest/index.html
Project-URL: repository, https://github.com/mlflow/mlflow-go-backend
Keywords: mlflow,go,golang,ai,databricks
Classifier: Development Status :: 5 - Production/Stable
Classifier: Intended Audience :: Developers
Classifier: Intended Audience :: End Users/Desktop
Classifier: Intended Audience :: Science/Research
Classifier: Intended Audience :: Information Technology
Classifier: Topic :: Scientific/Engineering :: Artificial Intelligence
Classifier: Topic :: Software Development :: Libraries :: Python Modules
Classifier: License :: OSI Approved :: Apache Software License
Classifier: Operating System :: OS Independent
Classifier: Programming Language :: Python :: 3.9
Requires-Python: >=3.9
Description-Content-Type: text/markdown
License-File: LICENSE
Requires-Dist: cffi>=1.17.1
Requires-Dist: mlflow>=2.19.0
Requires-Dist: psycopg2-binary>=2.9.9
```