### PR TITLE
Add better message for file store uris.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ To contribute to this project, you need the following:
 - [Mage](https://magefile.org/) (via `go install github.com/magefile/mage@v1.15.0`)
 - [protoc-gen-go](https://pkg.go.dev/github.com/golang/protobuf/protoc-gen-go) (via `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.33.0`)
 - [Mockery](https://vektra.github.io/mockery/latest/) (via `go install github.com/vektra/mockery/v2@v2.43.2`)
-- [Golangci-lint](https://golangci-lint.run/) (via `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1`)
+- [Golangci-lint](https://golangci-lint.run/) (via `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0`)
 
 ### Protocol Buffer Compiler
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ You can update your existing you used `mlflow` command with `mlflow-go`:
 
 Every existing setting of [mlflow server](https://mlflow.org/docs/latest/cli.html#mlflow-server) can be passed to `mlflow-go`.
 
+> [!CAUTION]
+> The Go implementation currently does not support file storage as a backend store. You must provide the --backend-store-uri argument pointing to a database.
+
 ### Python Usage
 
 ```py

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -21,6 +21,9 @@ var (
 	errSqliteMemory             = errors.New("go implementation does not support :memory: for sqlite")
 	errSqliteQueryParamsWindows = errors.New("query parameters are not supported on Windows")
 	errInUseConnections         = errors.New("there are still in use connections")
+	errNoSchemeDetected         = errors.New("no database schema was found," +
+		" we suspect you might be trying to use the file store which is not yet implemented." +
+		" Please pass a '--backend-store-uri' argument pointing to a database")
 )
 
 //nolint:ireturn
@@ -55,6 +58,10 @@ func getDialector(uri *url.URL) (gorm.Dialector, error) {
 
 		return sqlite.Open(dsn), nil
 	default:
+		if uri.Scheme == "" {
+			return nil, errNoSchemeDetected
+		}
+
 		return nil, fmt.Errorf("unsupported store URL scheme %q", uri.Scheme) //nolint:err113
 	}
 }


### PR DESCRIPTION
When running `mlflow server` without any further arguments, `mlflow` will use the file store by default and not sqlite.

I want to make it more clear for users trying `mlflow-go server` without any argument.