### PR TITLE
Avoid SQL error log

### DIFF
--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -95,7 +95,7 @@ func NewDatabase(ctx context.Context, storeURL string) (*gorm.DB, error) {
 
 	database, err := gorm.Open(dialector, &gorm.Config{
 		TranslateError: true,
-		Logger:         NewLoggerAdaptor(logger, LoggerAdaptorConfig{}),
+		Logger:         NewLoggerAdaptor(logger, LoggerAdaptorConfig{IgnoreRecordNotFoundError: true}),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database %q: %w", uri.String(), err)

--- a/pkg/tracking/store/sql/experiments.go
+++ b/pkg/tracking/store/sql/experiments.go
@@ -250,17 +250,10 @@ func (s TrackingSQLStore) RestoreExperiment(ctx context.Context, id string) *con
 func (s TrackingSQLStore) GetExperimentByName(
 	ctx context.Context, name string,
 ) (*entities.Experiment, *contract.Error) {
-	var experiment models.Experiment
+	var experiments []models.Experiment
 
-	err := s.db.WithContext(ctx).Preload("Tags").Where("name = ?", name).First(&experiment).Error
+	err := s.db.WithContext(ctx).Preload("Tags").Where("name = ?", name).Find(&experiments).Error
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, contract.NewError(
-				protos.ErrorCode_RESOURCE_DOES_NOT_EXIST,
-				fmt.Sprintf("Could not find experiment with name %s", name),
-			)
-		}
-
 		return nil, contract.NewErrorWith(
 			protos.ErrorCode_INTERNAL_ERROR,
 			fmt.Sprintf("failed to get experiment by name %s", name),
@@ -268,7 +261,14 @@ func (s TrackingSQLStore) GetExperimentByName(
 		)
 	}
 
-	return experiment.ToEntity(), nil
+	if len(experiments) == 0 {
+		return nil, contract.NewError(
+			protos.ErrorCode_RESOURCE_DOES_NOT_EXIST,
+			fmt.Sprintf("Could not find experiment with name %s", name),
+		)
+	}
+
+	return experiments[0].ToEntity(), nil
 }
 
 func (s TrackingSQLStore) SearchExperiments(


### PR DESCRIPTION
Fixes #119 

Okay, turns out this was working after all but very misleading.
I did see

![image](https://github.com/user-attachments/assets/60900f27-f035-43c5-a445-74594f5163fc)

But we already deal with this in:

https://github.com/mlflow/mlflow-go-backend/blob/8a621cc96da427300693c6ee428e5b883b4ca5bc/mlflow_go_backend/store/tracking.py#L87-L99
