### PR TITLE
mlflow-go server fails with AttributeError: module 'mlflow' has no attribute 'server'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-05-20
+
+### Fixed
+
+- AttributeError: module 'mlflow' has no attribute 'server' ([#134](https://github.com/mlflow/mlflow-go-backend/issues/134))
+
 ## [0.2.0] - 2025-01-27
 
 ### Added

--- a/mlflow_go_backend/cli.py
+++ b/mlflow_go_backend/cli.py
@@ -4,6 +4,7 @@ import shlex
 
 import click
 import mlflow.cli
+import mlflow.server
 import mlflow.version
 from mlflow.utils import find_free_port
 


### PR DESCRIPTION
Fix #134 

Actual behavior:
The CLI references mlflow.server.__file__ in mlflow_go_backend/cli.py without ever importing the mlflow.server submodule, so Python raises an AttributeError and exits.

Expected behavior:
The server should import the mlflow.server module, locate the static folder, initialize the backend store, and start serving the MLflow UI without error.

Root cause:
mlflow.server is never imported, so it isn’t attached to the mlflow namespace. Accessing mlflow.server.__file__ therefore fails.

Proposed fix:
Add an explicit import mlflow.server at the top of mlflow_go_backend/cli.py to ensure mlflow.server exists before accessing its attributes.